### PR TITLE
Bump the version to 0.0.10

### DIFF
--- a/lib/yamatanooroti/version.rb
+++ b/lib/yamatanooroti/version.rb
@@ -1,3 +1,3 @@
 class Yamatanooroti
-  VERSION = '0.0.9'
+  VERSION = '0.0.10'
 end


### PR DESCRIPTION
https://github.com/ruby/yamatanooroti/compare/d16c9cce6f99aec87bdc00335d5a8591bc52ba68..d6f94b44134c55a7750db37ccb8692ced9658136

Once this PR is merged, I want to tag `v0.0.10` to this repository and write that tag in Reline's Gemfile: https://github.com/hasumikin/reline/blob/reline_face/Gemfile#L9

```
gem "yamatanooroti", github: "ruby/yamatanooroti", tag: "v0.0.10"
```