### PR TITLE
Avoid warnings for frozen string literals

### DIFF
--- a/lib/yamatanooroti/vterm.rb
+++ b/lib/yamatanooroti/vterm.rb
@@ -30,7 +30,7 @@ module Yamatanooroti::VTermTestCaseModule
 
   def write(str)
     sync
-    str_to_write = String.new(encoding: Encoding::ASCII_8BIT)
+    str_to_write = +String.new(encoding: Encoding::ASCII_8BIT)
     str.chars.each do |c|
       byte = c.force_encoding(Encoding::ASCII_8BIT).ord
       if c.bytesize == 1 and byte.allbits?(0x80) # with Meta key
@@ -54,7 +54,7 @@ module Yamatanooroti::VTermTestCaseModule
   end
 
   private def sync
-    startup_message = '' if @startup_message
+    startup_message = +'' if @startup_message
     loop do
       sleep @wait
       chunk = @pty_output.read_nonblock(1024)
@@ -87,7 +87,7 @@ module Yamatanooroti::VTermTestCaseModule
     @result = []
     rows, cols = @vterm.size
     rows.times do |r|
-      @result << ''
+      @result << +''
       cols.times do |c|
         cell = @screen.cell_at(r, c)
         if cell.char # The second cell of fullwidth char will be nil.

--- a/lib/yamatanooroti/windows.rb
+++ b/lib/yamatanooroti/windows.rb
@@ -342,7 +342,7 @@ module Yamatanooroti::WindowsTestCaseModule
     end
 
     quote_hit = true
-    result = '"'
+    result = +'"'
     arg.chars.reverse.each do |c|
       result << c
       if quote_hit and c == '\\'
@@ -498,7 +498,7 @@ module Yamatanooroti::WindowsTestCaseModule
     screen = []
     prev_c = nil
     @height.times do |y|
-      line = ''
+      line = +''
       @width.times do |x|
         index = @width * y + x
         char_info = DL::CHAR_INFO.new(char_info_matrix + DL::CHAR_INFO.size * index)


### PR DESCRIPTION
Avoid the `warning: literal string will be frozen in the future` warning.