### PR TITLE
Better assertion with less wait time

### DIFF
--- a/lib/yamatanooroti/vterm.rb
+++ b/lib/yamatanooroti/vterm.rb
@@ -2,6 +2,7 @@ require 'test/unit'
 require 'vterm'
 require 'pty'
 require 'io/console'
+require 'io/wait'
 
 module Yamatanooroti::VTermTestCaseModule
   def start_terminal(height, width, command, wait: 0.01, timeout: 2, startup_message: nil)

--- a/lib/yamatanooroti/vterm.rb
+++ b/lib/yamatanooroti/vterm.rb
@@ -128,7 +128,7 @@ module Yamatanooroti::VTermTestCaseModule
     result
   end
 
-  private def assert_screen_with_proc(check_proc, assert_block, convert_proc = :itself.to_proc)
+  private def retryable_screen_assertion_with_proc(check_proc, assert_proc, convert_proc = :itself.to_proc)
     retry_until = Time.now + @timeout
     while Time.now < retry_until
       break unless try_sync
@@ -137,27 +137,27 @@ module Yamatanooroti::VTermTestCaseModule
       break if check_proc.call(convert_proc.call(@result))
     end
     @result ||= retrieve_screen
-    assert_block.call(convert_proc.call(@result))
+    assert_proc.call(convert_proc.call(@result))
   end
 
   def assert_screen(expected_lines, message = nil)
     lines_to_string = ->(lines) { lines.join("\n").sub(/\n*\z/, "\n") }
     case expected_lines
     when Array
-      assert_screen_with_proc(
-        ->(a) { expected_lines == a },
-        ->(a) { assert_equal(expected_lines, a, message) }
+      retryable_screen_assertion_with_proc(
+        ->(actual) { expected_lines == actual },
+        ->(actual) { assert_equal(expected_lines, actual, message) }
       )
     when String
-      assert_screen_with_proc(
-        ->(a) { expected_lines == a },
-        ->(a) { assert_equal(expected_lines, a, message) },
+      retryable_screen_assertion_with_proc(
+        ->(actual) { expected_lines == actual },
+        ->(actual) { assert_equal(expected_lines, actual, message) },
         lines_to_string
       )
     when Regexp
-      assert_screen_with_proc(
-        ->(a) { expected_lines.match?(a) },
-        ->(a) { assert_match(expected_lines, a, message) },
+      retryable_screen_assertion_with_proc(
+        ->(actual) { expected_lines.match?(actual) },
+        ->(actual) { assert_match(expected_lines, actual, message) },
         lines_to_string
       )
     end

--- a/lib/yamatanooroti/vterm.rb
+++ b/lib/yamatanooroti/vterm.rb
@@ -76,7 +76,12 @@ module Yamatanooroti::VTermTestCaseModule
 
   private def vterm_write(chunk)
     @vterm.write(chunk)
-    @pty_input.write(@vterm.read)
+    response = @vterm.read
+    begin
+      @pty_input.write(response)
+    rescue Errno::EIO
+      # In case process terminates suddenly after writing "\e[6n"
+    end
     @result = nil
   end
 

--- a/lib/yamatanooroti/windows.rb
+++ b/lib/yamatanooroti/windows.rb
@@ -516,15 +516,19 @@ module Yamatanooroti::WindowsTestCaseModule
   end
 
   def result
-    @result
+    @result || retrieve_screen
   end
 
   def assert_screen(expected_lines, message = nil)
+    actual_lines = result
+    actual_string = actual_lines.join("\n").sub(/\n*\z/, "\n")
     case expected_lines
     when Array
-      assert_equal(expected_lines, @result, message)
+      assert_equal(expected_lines, actual_lines, message)
     when String
-      assert_equal(expected_lines, @result.join("\n").sub(/\n*\z/, "\n"), message)
+      assert_equal(expected_lines, actual_string, message)
+    when Regexp
+      assert_match(expected_lines, actual_string, message)
     end
   end
 

--- a/test/yamatanooroti/test_multiplatform.rb
+++ b/test/yamatanooroti/test_multiplatform.rb
@@ -2,8 +2,7 @@ require 'yamatanooroti'
 
 class Yamatanooroti::TestMultiplatform < Yamatanooroti::TestCase
   def setup
-    start_terminal(5, 30, ['ruby', 'bin/simple_repl'])
-    sleep 0.5
+    start_terminal(5, 30, ['ruby', 'bin/simple_repl'], startup_message: 'prompt>')
   end
 
   def test_example
@@ -17,10 +16,29 @@ class Yamatanooroti::TestMultiplatform < Yamatanooroti::TestCase
     EOC
   end
 
-  def test_result
+  def test_result_repeatedly
     write(":a\n")
-    close
+    assert_screen(/=> :a\nprompt>/)
     assert_equal(['prompt> :a', '=> :a', 'prompt>', '', ''], result)
+    write(":b\n")
+    assert_screen(/=> :b\nprompt>/)
+    assert_equal(['prompt> :a', '=> :a', 'prompt> :b', '=> :b', 'prompt>'], result)
+    close
+  end
+
+  def test_assert_screen_retries
+    write("sleep 1\n")
+    assert_screen(/=> 1\nprompt>/)
+    assert_equal(['prompt> sleep 1', '=> 1', 'prompt>', '', ''], result)
+    close
+  end
+
+  def test_assert_screen_timeout
+    write("sleep 3\n")
+    assert_raise do
+      assert_screen(/=> 3\nprompt>/)
+    end
+    close
   end
 
   def test_auto_wrap
@@ -38,12 +56,14 @@ class Yamatanooroti::TestMultiplatform < Yamatanooroti::TestCase
   def test_fullwidth
     write(":あ\n")
     close
+    assert_screen(/=> :あ\nprompt>/)
     assert_equal(['prompt> :あ', '=> :あ', 'prompt>', '', ''], result)
   end
 
   def test_two_fullwidth
     write(":あい\n")
     close
+    assert_screen(/=> :あい\nprompt>/)
     assert_equal(['prompt> :あい', '=> :あい', 'prompt>', '', ''], result)
   end
 end

--- a/test/yamatanooroti/test_run_ruby.rb
+++ b/test/yamatanooroti/test_run_ruby.rb
@@ -26,19 +26,20 @@ class Yamatanooroti::TestRunRuby < Yamatanooroti::TestCase
 
   def test_move_cursor_and_render
     start_terminal(5, 30, ['ruby', '-rio/console', '-e', 'STDOUT.puts(?A);STDOUT.goto(2,2);STDOUT.puts(?B)'])
+    assert_screen(/^  B/)
     close
     assert_equal(['A', '', '  B', '', ''], result)
   end
 
   def test_meta_key
     get_into_tmpdir
-    start_terminal(5, 30, ['ruby', '-rreline', '-e', 'Reline.readline(%{?})'])
+    start_terminal(5, 30, ['ruby', '-rreline', '-e', 'Reline.readline(%{>>>})'], startup_message: />{3}/)
     write('aaa ccc')
     write("\M-b")
     write('bbb ')
     close
     assert_screen(<<~EOC)
-      ?aaa bbb ccc
+      >>>aaa bbb ccc
     EOC
   ensure
     get_out_from_tmpdir


### PR DESCRIPTION
Need to merge https://github.com/ruby/irb/pull/1000 and https://github.com/ruby/reline/pull/746 first


There are good E2E tests and bad E2E tests.
```ruby
require 'capybara'

# Good E2E test
click_link('bar')
expect(page).to have_content('baz') # This will automatically retries

# Bad and slow E2E test
click_link('bar')
sleep 1 # Need to sleep enough time because there is no retry in the assertion below
expect(page.content).to include('baz')
```

Yamatanooroti should provide a way to write good E2E test for fast and stable testing.

- `write` should not sleep 0.1sec(before write) + 0.1sec(after write). It should be faster.
- `assert_screen` should retry with a very short wait time.
- `assert_screen` should accept regexp to avoid `sleep t; assert_match(result.join, /pattern/)`
- Should be able to call `assert_screen` and `result` several times in a single test case.

### Example using the new feature
```ruby
start_terminal(rows, cols, command, startup_message: /irb\(main\):001>/)
write "sleep 1\n"
# Wait until irb is ready
assert_screen(/irb\(main\):002>/)
write "debug\n"
# Wait until rdbg is ready
assert_screen(/irb:rdbg/)
write "foobar\n"
# Assert result
assert_screen(expected_result)
close
```

### IRB and Reline test
IRB and Reline's test implicitly depend on `wait=0.1`, so test will fail. We need to properly set startup_message and/or add an assert_screen before some write operations.

Expected performance improvements are:
Reline test_yamatanooroti: 3:30 -> 0:50
IRB test_yamatanooroti: 0:38 -> 0:12

Branches:
https://github.com/tompng/reline/tree/new_yamatanooroti
https://github.com/tompng/irb/tree/new_yamatanooroti
