### PR TITLE
Always close after assert_screen to make test stable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ class MyTest < Yamatanooroti::TestCase
 
   def test_example
     write(":a\n")
-    close
     assert_screen(['irb(main):001:0> :a', '=> :a', 'irb(main):002:0>', '', ''])
+    close
   end
 end
 ```
@@ -63,8 +63,8 @@ class MyTest < Yamatanooroti::VTermTestCase
 
   def test_example
     write(":a\n")
-    close
     assert_screen(['irb(main):001:0> :a', '=> :a', 'irb(main):002:0>', '', ''])
+    close
   end
 end
 ```
@@ -82,15 +82,15 @@ Starts terminal internally that is sized `height` and `width` with `command` to 
 If `startup_message` is given, `start_terminal` waits for the string to be printed and then returns.
 
 ```ruby
-code = 'sleep 1; puts "aaa"; sleep 10; puts "bbb"'
-start_terminal(5, 30, ['ruby', '-e', code], startup_message: 'aaa')
-close
+code = 'sleep 1; print "prompt>"; s = gets; sleep 1; puts s.upcase'
+start_terminal(5, 30, ['ruby', '-e', code], startup_message: 'prompt>')
+# Screen is already "prompt>"
+write "hello\n"
 assert_screen(<<~EOC)
-  aaa
+  prompt>hello
+  HELLO
 EOC
-# The start_terminal method waits for the output of the "aaa" as specified by
-# the startup_message option, the "bbb" after 10 seconds won't come because
-# the I/O is closed immediately after it.
+close
 ```
 
 ### `write(str)`

--- a/README.md
+++ b/README.md
@@ -15,11 +15,8 @@ You can test the executed result and its rendering on the automatically detected
 require 'yamatanooroti'
 
 class MyTest < Yamatanooroti::TestCase
-  def setup
-    start_terminal(5, 30, ['irb', '-f', '--multiline'])
-  end
-
   def test_example
+    start_terminal(5, 30, ['irb', '-f', '--multiline'])
     write(":a\n")
     assert_screen(['irb(main):001:0> :a', '=> :a', 'irb(main):002:0>', '', ''])
     close
@@ -57,11 +54,8 @@ If you want to specify vterm environment that needs vterm gem, you can use `Yama
 require 'yamatanooroti'
 
 class MyTest < Yamatanooroti::VTermTestCase
-  def setup
-    start_terminal(5, 30, ['irb', '-f', '--multiline'])
-  end
-
   def test_example
+    start_terminal(5, 30, ['irb', '-f', '--multiline'])
     write(":a\n")
     assert_screen(['irb(main):001:0> :a', '=> :a', 'irb(main):002:0>', '', ''])
     close

--- a/test/yamatanooroti/test_multiplatform.rb
+++ b/test/yamatanooroti/test_multiplatform.rb
@@ -5,6 +5,10 @@ class Yamatanooroti::TestMultiplatform < Yamatanooroti::TestCase
     start_terminal(5, 30, ['ruby', 'bin/simple_repl'], startup_message: 'prompt>')
   end
 
+  def teardown
+    close
+  end
+
   def test_example
     write(":a\n")
     assert_screen(['prompt> :a', '=> :a', 'prompt>', '', ''])
@@ -13,7 +17,6 @@ class Yamatanooroti::TestMultiplatform < Yamatanooroti::TestCase
       => :a
       prompt>
     EOC
-    close
   end
 
   def test_result_repeatedly
@@ -23,14 +26,12 @@ class Yamatanooroti::TestMultiplatform < Yamatanooroti::TestCase
     write(":b\n")
     assert_screen(/=> :b\nprompt>/)
     assert_equal(['prompt> :a', '=> :a', 'prompt> :b', '=> :b', 'prompt>'], result)
-    close
   end
 
   def test_assert_screen_retries
     write("sleep 1\n")
     assert_screen(/=> 1\nprompt>/)
     assert_equal(['prompt> sleep 1', '=> 1', 'prompt>', '', ''], result)
-    close
   end
 
   def test_assert_screen_timeout
@@ -38,7 +39,6 @@ class Yamatanooroti::TestMultiplatform < Yamatanooroti::TestCase
     assert_raise do
       assert_screen(/=> 3\nprompt>/)
     end
-    close
   end
 
   def test_auto_wrap
@@ -50,20 +50,17 @@ class Yamatanooroti::TestMultiplatform < Yamatanooroti::TestCase
       => 12345678901234567890123
       prompt>
     EOC
-    close
   end
 
   def test_fullwidth
     write(":あ\n")
     assert_screen(/=> :あ\nprompt>/)
     assert_equal(['prompt> :あ', '=> :あ', 'prompt>', '', ''], result)
-    close
   end
 
   def test_two_fullwidth
     write(":あい\n")
     assert_screen(/=> :あい\nprompt>/)
     assert_equal(['prompt> :あい', '=> :あい', 'prompt>', '', ''], result)
-    close
   end
 end

--- a/test/yamatanooroti/test_multiplatform.rb
+++ b/test/yamatanooroti/test_multiplatform.rb
@@ -7,13 +7,13 @@ class Yamatanooroti::TestMultiplatform < Yamatanooroti::TestCase
 
   def test_example
     write(":a\n")
-    close
     assert_screen(['prompt> :a', '=> :a', 'prompt>', '', ''])
     assert_screen(<<~EOC)
       prompt> :a
       => :a
       prompt>
     EOC
+    close
   end
 
   def test_result_repeatedly
@@ -43,7 +43,6 @@ class Yamatanooroti::TestMultiplatform < Yamatanooroti::TestCase
 
   def test_auto_wrap
     write("12345678901234567890123\n")
-    close
     assert_screen(['prompt> 1234567890123456789012', '3', '=> 12345678901234567890123', 'prompt>', ''])
     assert_screen(<<~EOC)
       prompt> 1234567890123456789012
@@ -51,19 +50,20 @@ class Yamatanooroti::TestMultiplatform < Yamatanooroti::TestCase
       => 12345678901234567890123
       prompt>
     EOC
+    close
   end
 
   def test_fullwidth
     write(":あ\n")
-    close
     assert_screen(/=> :あ\nprompt>/)
     assert_equal(['prompt> :あ', '=> :あ', 'prompt>', '', ''], result)
+    close
   end
 
   def test_two_fullwidth
     write(":あい\n")
-    close
     assert_screen(/=> :あい\nprompt>/)
     assert_equal(['prompt> :あい', '=> :あい', 'prompt>', '', ''], result)
+    close
   end
 end

--- a/test/yamatanooroti/test_run_ruby.rb
+++ b/test/yamatanooroti/test_run_ruby.rb
@@ -4,31 +4,29 @@ require 'tmpdir'
 class Yamatanooroti::TestRunRuby < Yamatanooroti::TestCase
   def test_winsize
     start_terminal(5, 30, ['ruby', '-rio/console', '-e', 'puts(IO.console.winsize.inspect)'])
-    sleep 0.5
-    close
     assert_screen(<<~EOC)
       [5, 30]
     EOC
+    close
   end
 
   def test_wait_for_startup_message
-    code = 'sleep 1; puts "aaa"; sleep 10; puts "bbb"'
-    start_terminal(5, 30, ['ruby', '-e', code], startup_message: 'aaa')
-    # The start_terminal method waits 1 sec for "aaa" as specified by
-    # wait_for_startup_message option and close immediately by the close
-    # method at the next line. The next "bbb" after waiting 1 sec more doesn't
-    # be caught because I/O is already closed.
-    close
+    code = 'sleep 1; print "prompt>"; s = gets; sleep 1; puts s.upcase'
+    start_terminal(5, 30, ['ruby', '-e', code], startup_message: 'prompt>')
+    assert_equal(['prompt>', '', '', '', ''], result)
+    write "hello\n"
     assert_screen(<<~EOC)
-      aaa
+      prompt>hello
+      HELLO
     EOC
+    close
   end
 
   def test_move_cursor_and_render
     start_terminal(5, 30, ['ruby', '-rio/console', '-e', 'STDOUT.puts(?A);STDOUT.goto(2,2);STDOUT.puts(?B)'])
-    assert_screen(/^  B/)
-    close
+    assert_screen(['A', '', '  B', '', ''])
     assert_equal(['A', '', '  B', '', ''], result)
+    close
   end
 
   def test_meta_key
@@ -37,22 +35,22 @@ class Yamatanooroti::TestRunRuby < Yamatanooroti::TestCase
     write('aaa ccc')
     write("\M-b")
     write('bbb ')
-    close
     assert_screen(<<~EOC)
       >>>aaa bbb ccc
     EOC
+    close
   ensure
     get_out_from_tmpdir
   end
 
   def test_assert_screen_takes_a_message_when_failed
     start_terminal(5, 30, ['ruby', '-e', 'puts "aaa"'])
-    close
     assert_raise_with_message Test::Unit::AssertionFailedError, /\Amessage when failed/ do
       assert_screen(<<~EOC, 'message when failed')
         bbb
       EOC
     end
+    close
   end
 
   private

--- a/test/yamatanooroti/test_run_ruby.rb
+++ b/test/yamatanooroti/test_run_ruby.rb
@@ -2,12 +2,15 @@ require 'yamatanooroti'
 require 'tmpdir'
 
 class Yamatanooroti::TestRunRuby < Yamatanooroti::TestCase
+  def teardown
+    close
+  end
+
   def test_winsize
     start_terminal(5, 30, ['ruby', '-rio/console', '-e', 'puts(IO.console.winsize.inspect)'])
     assert_screen(<<~EOC)
       [5, 30]
     EOC
-    close
   end
 
   def test_wait_for_startup_message
@@ -19,14 +22,12 @@ class Yamatanooroti::TestRunRuby < Yamatanooroti::TestCase
       prompt>hello
       HELLO
     EOC
-    close
   end
 
   def test_move_cursor_and_render
     start_terminal(5, 30, ['ruby', '-rio/console', '-e', 'STDOUT.puts(?A);STDOUT.goto(2,2);STDOUT.puts(?B)'])
     assert_screen(['A', '', '  B', '', ''])
     assert_equal(['A', '', '  B', '', ''], result)
-    close
   end
 
   def test_meta_key
@@ -38,7 +39,6 @@ class Yamatanooroti::TestRunRuby < Yamatanooroti::TestCase
     assert_screen(<<~EOC)
       >>>aaa bbb ccc
     EOC
-    close
   ensure
     get_out_from_tmpdir
   end
@@ -50,7 +50,6 @@ class Yamatanooroti::TestRunRuby < Yamatanooroti::TestCase
         bbb
       EOC
     end
-    close
   end
 
   private


### PR DESCRIPTION
Fixes REAME and all test that closes before assertion.
Fixes #18

After #10, assert_screen can be called several times in a single test. We don't have to close before assert_screen anymore.
Closing before assert_screen has some problem. We need #15 to perform test that closes stdin before assertion, so the preferred form is to always close after all assertions.
```ruby
start_terminal(...)
write(a)
assert_screen(b)
write(c)
assert_screen(d)
...
close
```

In #10, I forgot to change the order of `assert_screen` and `close` because test was passing, but it turned out to be flaky.
